### PR TITLE
Added some functionality to sleep command and tasks implementation

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -825,6 +825,11 @@ class Console::CommandDispatcher::Core
     print_status("Telling the target instance to sleep for #{seconds} seconds ...")
     if client.core.transport_sleep(seconds)
       print_good("Target instance has gone to sleep, terminating current session.")
+      print_good("---------------------------------------------")
+      print_good("Current time: #{Time.at(Time.now.to_i)}")
+      print_good("Meterpreter will connect at #{Time.at(Time.now.to_i+seconds)}")
+      print_good("---------------------------------------------")
+      client.core.tasks
       client.shutdown_passive_dispatcher
       shell.stop
     else


### PR DESCRIPTION
I was wondering how to execute components of an attack automatically while using the Metasploit c2 platform. I have found “task chains” features that would do it to some extent. But unfortunately the “task chains” are in the Metasploit PRO version. Another key feature that I’m missing in Metasploit is irregular connection intervals.

I decided to take a look closer at this topic and see how I can automate some phases of an attack.

More information:
[(https://medium.com/@dawid.golak/attack-automation-with-metasploit-tasks-c389a4c2e3a6)]
[(https://twitter.com/dawid_golak)]